### PR TITLE
Add support for any custom fields in the design doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,23 +96,31 @@ type CouchifyOptions = {
 * `baseDocumentsDir` is where your source code is located. This directory should contain at least one of the `filtersDir`, `listsDir`, `showsDir`, `updatesDir` or `viewsDir` directories. These are respectively is been set to: `filters`, `lists`, `shows`, `updates` and `views`.
 * By default, `couchify` only applies [ES2015 preset](https://babeljs.io/docs/plugins/preset-es2015/), you can add extra Babel plugins and presets with `babelPlugins` and `babelPresets` options.
 
-### Rewrites
+### Custom fields
 
-Just add a `rewrites.json` file in your base documents folder. This file should be formatted like the following example:
+You can customize the design document by adding a `template.json` to the base
+folder. Its contents will be merged with the final design document.
 
-```
-[
+For more advanced templating, you can use a `template.js`-file exporting a
+function instead. The function will be called with the CouchifyOptions to
+produce the template.
+
+For example:
+
+```js
+module.exports = options => ({
+  name: options.id,
+  version: require('../package.json').version,
+  rewrites: [
     {
-        "from": "",
-        "to": "index.html",
-        "method": "GET",
-        "query": {}
-    },
-    ...
-]
+      from: '',
+      to: 'index.html',
+      method: 'GET',
+      query: {}
+    }
+  ]
+})
 ```
-
-See: http://docs.couchdb.org/en/1.3.0/pretty_urls.html
 
 ### Deploying
 

--- a/fixtures/template/expected.json
+++ b/fixtures/template/expected.json
@@ -1,0 +1,6 @@
+{
+    "_id": "_design/template",
+    "language": "javascript",
+    "foo": "bar",
+    "baz": "template"
+}

--- a/fixtures/template/template.js
+++ b/fixtures/template/template.js
@@ -1,0 +1,4 @@
+module.exports = options => ({
+  foo: 'bar',
+  baz: options.id
+});

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -2,8 +2,7 @@ import * as minimist from 'minimist'
 import * as path from 'path'
 import * as client from './client'
 import { couchify } from './couchify'
-import { readFileAsync } from './helpers'
-import { CouchifyOptions, DesignDocument, Rewrite } from './interfaces'
+import { CouchifyOptions, DesignDocument } from './interfaces'
 
 const argv: any = minimist(process.argv.slice(2), {
     alias: {
@@ -46,23 +45,7 @@ if ((!dir && !argv.version) || argv.help) {
         }
     })
 
-    Promise.all([
-        couchify(options),
-        readFileAsync(path.join(baseDocumentsDir, 'rewrites.json'), 'utf8')
-            .then(res => {
-                let json = []
-                try {
-                    json = JSON.parse(res)
-                } catch (e) {
-                    console.warn('malformed rewrites.json')
-                }
-                return json
-            })
-            .catch(readFileErr => [])
-    ]).then(([designDocument, rewrites]: [DesignDocument, Rewrite[]]) => {
-        if (rewrites.length) {
-            designDocument.rewrites = rewrites
-        }
+    couchify(options).then((designDocument: DesignDocument) => {
 
         if (!argv.dry) {
             return client
@@ -84,6 +67,7 @@ if ((!dir && !argv.version) || argv.help) {
         console.error('[error] ' + er.message)
         process.exit(1)
     })
+
 }
 
 function showUsage() {

--- a/src/couchify.ts
+++ b/src/couchify.ts
@@ -182,10 +182,8 @@ function rewriteRequires(src: string, fn: (name: string) => string | void): Prom
 }
 
 function designDocument(values: FunctionResolution[], resolutionIndex, resolvedDeps: DependencyResolution[], attachments: Attachment[], options: CouchifyOptions) {
-    const res: DesignDocument = {
-        _id: `_design/${options.id}`,
-        language: 'javascript'
-    }
+
+    const res: DesignDocument = createDesignDocumentTemplate(options);
 
     if (attachments.length) {
         res._attachments = attachments.reduce((acc, attachment) => {
@@ -234,4 +232,19 @@ function designDocument(values: FunctionResolution[], resolutionIndex, resolvedD
     }
 
     return res
+}
+
+function createDesignDocumentTemplate(options: CouchifyOptions): DesignDocument {
+    const overrides: DesignDocument = {
+        _id: `_design/${options.id}`,
+        language: 'javascript'
+    };
+
+    try{
+        const tmpl = require(path.resolve(options.baseDocumentsDir, 'template'));
+        const template = typeof tmpl === 'function' ? tmpl(options) : tmpl;
+        return {...template, ...overrides};
+    } catch (e) {
+        return overrides;
+    }
 }

--- a/src/test/couchify.ts
+++ b/src/test/couchify.ts
@@ -115,10 +115,11 @@ function runTests() {
         ;
 
     [
+        'attachments',
         'babel-plugin',
         'basic',
         'gamma',
-        'attachments'
+        'template'
     ].forEach(d => {
         test('fixtures/' + d, t => {
             let opts = {


### PR DESCRIPTION
* Removes the rewrites-specific feature
* Adds a generic "design doc user-template" feature in its place. It can be used to set rewrites, as well as other stuff, and even computed fields.