### PR TITLE
Integrate xyz release tool

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 5984:5984
   couchify:
     image: mhart/alpine-node:8.5.0
-    command: sh -c "cd /build && yarn && npm run lint && npm run build && NODE_ENV=docker npm run test"
+    command: sh -c "cd /build && yarn && npm run lint && NODE_ENV=docker npm run test"
     links:
       - "couchdb"
     depends_on:

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "couchify",
   "description": "use next generation JS in your CouchDB apps",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "main": "lib/index.js",
   "author": "wearereasonablepeople",
   "license": "MIT",
   "scripts": {
     "build": "rimraf lib && tsc",
     "lint": "tslint src/**/*.ts --project tsconfig.json --type-check",
-    "test": "tape lib/test/**/*.js | tap-diff"
+    "pretest": "npm run build",
+    "test": "tape lib/test/**/*.js | tap-diff",
+    "release": "xyz --edit --repo git@github.com:wearereasonablepeople/couchify.git --increment"
   },
   "bin": {
     "couchify": "cmd.js"
@@ -32,7 +34,8 @@
     "stream-to-array": "^2.3.0",
     "toposort": "^1.0.3",
     "transform-deps": "^2.0.0",
-    "uniq": "^1.0.1"
+    "uniq": "^1.0.1",
+    "xyz": "^2.1.0"
   },
   "devDependencies": {
     "@types/acorn": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,6 +1300,10 @@ safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+semver@5.3.x:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
 semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -1564,3 +1568,9 @@ wrappy@1:
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xyz@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/xyz/-/xyz-2.1.0.tgz#c3ca897f156d2178bd818cd503f94b0a3b52fa6c"
+  dependencies:
+    semver "5.3.x"


### PR DESCRIPTION
From now on we should be able to release by using `npm run release minor`, for example.

Fixes #37 