### PR TITLE
Handle views based on file name instead of export name

### DIFF
--- a/fixtures/basic/expected.json
+++ b/fixtures/basic/expected.json
@@ -13,7 +13,8 @@
   },
   "views": {
     "test": {
-      "map": " (function(){\n\nreturn function (doc) {\n        emit(doc._id, require('views/lib/0').bar);\n    };\n\n}())"
+      "map": "(function(){\n\nreturn function (doc) {\n        emit(doc._id, require('views/lib/0').bar);\n    };\n\n}())",
+      "reduce": "(function(){\n\nreturn function (keys) {\n        return Math.max.apply(null, keys);\n    };\n\n}())"
     },
     "lib": {
       "0": "\"use strict\";\n\nexports.bar = 41;"

--- a/fixtures/basic/views/test.map.js
+++ b/fixtures/basic/views/test.map.js
@@ -1,3 +1,3 @@
-export const map = ({ emit }) => (doc) => {
+export default ({ emit }) => (doc) => {
     emit(doc._id, require('../lib/foo').bar)
 }

--- a/fixtures/basic/views/test.reduce.js
+++ b/fixtures/basic/views/test.reduce.js
@@ -1,0 +1,3 @@
+export default () => (keys) => {
+    return Math.max.apply(null, keys)
+}

--- a/fixtures/custom-dirs/expected.json
+++ b/fixtures/custom-dirs/expected.json
@@ -6,7 +6,7 @@
     },
     "views": {
         "bar": {
-            "map": " (function(){\n\nreturn function (doc) {\n        return 'okmap';\n    };\n\n}())"
+            "map": "(function(){\n\nreturn function (doc) {\n        return 'okmap';\n    };\n\n}())"
         }
     }
 }

--- a/fixtures/custom-dirs/v/bar.js
+++ b/fixtures/custom-dirs/v/bar.js
@@ -1,3 +1,0 @@
-export const map = ({ require }) => (doc) => {
-    return 'okmap'
-}

--- a/fixtures/custom-dirs/v/bar.map.js
+++ b/fixtures/custom-dirs/v/bar.map.js
@@ -1,0 +1,3 @@
+export default ({ require }) => (doc) => {
+    return 'okmap'
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "@types/acorn": "^4.0.2",
-    "@types/estree": "^0.0.37",
     "@types/glob": "^5.0.32",
     "@types/mime-types": "^2.1.0",
     "@types/minimist": "^1.2.0",

--- a/src/error.ts
+++ b/src/error.ts
@@ -3,7 +3,8 @@ export enum ErrorType {
     NOT_PROVIDED_BASE_DOCUMENTS_DIR,
     NOT_PROVIDED_ID,
     NOT_UNIQUE_DIRNAMES,
-    COULD_NOT_INSERT
+    COULD_NOT_INSERT,
+    NO_EXPORT
 }
 
 const messages = {
@@ -11,7 +12,8 @@ const messages = {
     [ErrorType.NOT_FOUND_BASE_DOCUMENTS_DIR]: 'base directory does not exist',
     [ErrorType.NOT_PROVIDED_BASE_DOCUMENTS_DIR]: 'you must provide a directory',
     [ErrorType.NOT_PROVIDED_ID]: 'you must provide a design document name',
-    [ErrorType.NOT_UNIQUE_DIRNAMES]: 'design function directory names must be unique'
+    [ErrorType.NOT_UNIQUE_DIRNAMES]: 'design function directory names must be unique',
+    [ErrorType.NO_EXPORT]: 'a design document did not export a default function'
 }
 
 export class CouchifyError extends Error {

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,35 +1,40 @@
 import * as acorn from 'acorn'
-import * as ESTree from 'estree'
 import * as mime from 'mime-types'
 import * as path from 'path'
 import { Attachment, CouchifyOptions, DependencyResolution, FunctionResolution } from './interfaces'
+import {CouchifyError, ErrorType} from './error'
 
 const designFunctionTypes = ['filters', 'lists', 'shows', 'updates', 'views']
 
 const esModuleTagMatcher = new RegExp('^Object.defineProperty\\(exports\\, "__esModule"\, \{\\s+value\:\\s+true\\s+\}\\)\;')
 const useStrictMatcher = /^[\'\"]{1,}use strict[\'\"]{1,}\;\s+/
 
-export function formatAsDesignFunctionEntry(baseDocumentsDir: string, relativePath: string, deps: DependencyResolution[], options: CouchifyOptions) {
+export function formatAsDesignFunctionEntry(relativePath: string, deps: DependencyResolution[], options: CouchifyOptions): FunctionResolution {
   const entry = deps[deps.length - 1] as FunctionResolution
-  entry.exports = extractExports(entry.source)
-  entry.resolvedDeps = deps.slice(0, -1)
-  const frags = relativePath.split('/')
-  entry.type = designFunctionTypes[[
+  const pathFragments = relativePath.split(/[/.]/).slice(0, -1)
+  const iife = transformExportsToIife(entry.source)
+  if (!iife) throw new CouchifyError(ErrorType.NO_EXPORT, relativePath)
+  const root = designFunctionTypes[[
     options.filtersDir,
     options.listsDir,
     options.showsDir,
     options.updatesDir,
     options.viewsDir
-  ].indexOf(frags[0])]
-  return entry
+  ].indexOf(pathFragments[0])]
+  return {
+    ...entry,
+    output: iife,
+    resolvedDeps: deps.slice(0, -1),
+    path: [root, ...pathFragments.slice(1)]
+  }
 }
 
 export function formatAsAttachmentEntry(attachmentsDir: string, relativePath: string, absPath: string, data: any): Attachment {
   const contentType = mime.contentType(path.basename(absPath))
   return {
-      id: relativePath,
-      content_type: contentType || 'application/octet-stream',
-      data: data.toString('base64')
+    id: relativePath,
+    content_type: contentType || 'application/octet-stream',
+    data: data.toString('base64')
   }
 }
 
@@ -38,58 +43,37 @@ export function formatAsAttachmentEntry(attachmentsDir: string, relativePath: st
  *
  * @param source  CommonJS source.
  */
-function extractExports(source: string): { [key: string]: string } | null {
+function transformExportsToIife(source: string): string | null {
   const ast = acorn.parse(source)
-  const moduleExports: { [key: string]: string } = {}
 
   if (!Array.isArray(ast.body)) {
-      return moduleExports
+    return null
   }
 
-  for (let node of ast.body) {
-      if (!(node && typeof node.type === 'string')) {
-          continue
-      }
+  const exportExpression:any = ast.body.find(node =>
+    node &&
+    node.type === 'ExpressionStatement' &&
+    typeof node.expression === 'object' &&
+    node.expression.type === 'AssignmentExpression' &&
+    typeof node.expression.left === 'object' &&
+    node.expression.left.type === 'MemberExpression' &&
+    typeof node.expression.right === 'object' &&
+    node.expression.right.type === 'FunctionExpression'
+  )
 
-      if (node.type === 'ExpressionStatement'
-          && node.expression
-          && node.expression.type === 'AssignmentExpression'
-          && node.expression.left && node.expression.left.type === 'MemberExpression'
-          && node.expression.right && node.expression.right.type === 'FunctionExpression') {
-
-          moduleExports.default = buildFunction(source, node, node.expression.right.body)
-          break
-
-      } else if (node.type === 'VariableDeclaration'
-          && Array.isArray(node.declarations)
-          && node.declarations[0].type === 'VariableDeclarator') {
-
-          const varId = node.declarations[0].id as ESTree.Identifier
-          const varAssignment = node.declarations[0].init as ESTree.AssignmentExpression
-          const varAssignmentLeft = varAssignment.left as ESTree.MemberExpression
-
-          if (varAssignmentLeft) {
-              const varAssignmentLeftObject = varAssignmentLeft.object as ESTree.Identifier
-              const varAssignmentLeftProperty = varAssignmentLeft.property as ESTree.Identifier
-              if (varAssignmentLeftObject.name === 'exports' && varId.name === varAssignmentLeftProperty.name) {
-                  const varAssignmentRight = varAssignment.right as ESTree.FunctionExpression
-                  moduleExports[varId.name] = buildFunction(source, node, varAssignmentRight.body)
-              }
-          }
-      }
+  if (!exportExpression) {
+    return null
   }
 
-  return moduleExports
-}
+  const functionBody = exportExpression.expression.right.body;
+  const returnValue = functionBody.body[functionBody.body.length - 1] as any
+  const extractedReturnValue = source.slice(0, exportExpression.start)
+                             + source.slice(returnValue.start, returnValue.end)
+                             + source.slice(exportExpression.end)
 
-function buildFunction(source: string, node: ESTree.Node, wrapper: ESTree.BlockStatement) {
-    const func = wrapper.body[wrapper.body.length - 1] as any
-    source = source.slice(0, (node as any).start)
-           + source.slice(func.start, func.end)
-           + source.slice((node as any).end)
+  const cleanedReturnValue = extractedReturnValue.replace(useStrictMatcher, '')
+                                                 .replace(esModuleTagMatcher, '')
+                                                 .trim()
 
-    source = source.replace(useStrictMatcher, '')
-    source = source.replace(esModuleTagMatcher, '')
-
-    return '(function(){\n\n' + source.trim() + '\n\n}())'
+  return '(function(){\n\n' + cleanedReturnValue + '\n\n}())'
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,10 +19,17 @@ export interface CouchifyOptions {
 }
 
 export interface DependencyResolution {
+    entry?: boolean
     deps: { [s: string]: string }
     file: string
     id: string
     source: string
+}
+
+export interface FunctionResolution extends DependencyResolution {
+    output: string
+    resolvedDeps: DependencyResolution[]
+    path: string[]
 }
 
 export interface DesignDocument {
@@ -40,13 +47,6 @@ export interface DesignDocument {
     filters?: { [key: string]: string }
     updates?: { [key: string]: string }
     rewrites?: Rewrite[]
-}
-
-export interface FunctionResolution extends DependencyResolution {
-    entry?: boolean
-    exports: { [s: string]: string }
-    resolvedDeps: DependencyResolution[]
-    type: string
 }
 
 export interface Rewrite {

--- a/src/test/couchify.ts
+++ b/src/test/couchify.ts
@@ -132,7 +132,7 @@ function runTests() {
             }
 
             couchify(opts).then(actual => {
-                t.deepEqual(actual, require(fixturesDir + '/' + d + '/expected.json'))
+                t.deepEqual(require(fixturesDir + '/' + d + '/expected.json'), actual)
                 t.end()
             }).catch(er => t.error(er))
         })
@@ -148,7 +148,7 @@ test('fixtures/custom-dirs', t => {
     }
 
     couchify(opts).then(actual => {
-        t.deepEqual(actual, require(fixturesDir + '/custom-dirs/expected.json'))
+        t.deepEqual(require(fixturesDir + '/custom-dirs/expected.json'), actual)
         t.end()
     }).catch(er => t.error(er))
 })


### PR DESCRIPTION
This changes the view compilation from named exports to file-based. Users can use dots (`.`) or slashes (`/`) to determine where a function will live in the ddoc. The reason for this change is to allow map and reduce functions to be compiled from separate files, which fixes #38.
