### PR TITLE
Replace record overload signature with union for TS-3.x compat

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,9 +39,8 @@ export interface DesignDocument {
     _attachments?: { [key: string]: Attachment }
     commons?: { [key: string]: string }
     views?: {
-        lib?: { [key: string]: string }
         [key: string]: string | { [key: string]: string }
-    }
+    } & { lib?: { [key: string]: string } }
     shows?: { [key: string]: string }
     lists?: { [key: string]: string }
     filters?: { [key: string]: string }


### PR DESCRIPTION
noticed couchify is giving me this type error when using TS 3.x

> Property 'lib' of type '{ [key: string]: string; } | undefined' is not assignable to string index type 'string | { [key: string]: string; }'.

This change moves optional `lib` definition outside of `views` so it doesn't collide with the non nullable record typing in there.